### PR TITLE
Themes: Expose DatePickerDialog theme

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -318,4 +318,6 @@
     <style name="ContactsAlertDialogTheme" parent="@android:style/Theme.Material.Light.Dialog">
         <item name="android:colorAccent">@color/primary_color</item>
     </style>
+    
+    <style name="DatePickerDialogTheme" parent="@android:style/Theme.DeviceDefault.Light"/>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -319,5 +319,6 @@
         <item name="android:colorAccent">@color/primary_color</item>
     </style>
     
+    <!--Date picker dialog theme-->
     <style name="DatePickerDialogTheme" parent="@android:style/Theme.DeviceDefault.Light"/>
 </resources>

--- a/src/com/android/contacts/datepicker/DatePickerDialog.java
+++ b/src/com/android/contacts/datepicker/DatePickerDialog.java
@@ -105,7 +105,7 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
             int monthOfYear,
             int dayOfMonth,
             boolean yearOptional) {
-        this(context, THEME_DEVICE_DEFAULT_LIGHT, callBack, year, monthOfYear, dayOfMonth,
+        this(context, R.style.DatePickerDialogTheme, callBack, year, monthOfYear, dayOfMonth,
                 yearOptional);
     }
 


### PR DESCRIPTION
This commit may be (probably is) incorrect with styles added in styles.xml, but the date picker dialog needs to be exposed. This helps themers creating dark themes especially. Thanks in advance.
